### PR TITLE
Fixing Navigation drawer

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -39,14 +39,14 @@ class _HomePageState extends State<HomePage> {
       appBar: AppBar(
         title: customTitle,
         backgroundColor: Colors.deepOrange,
-        leading: IconButton(
-          tooltip: "Menu",
-          icon: Icon(Icons.menu),
-          onPressed: () {
-            //Leading are the things before title
-            print("Menu");
-          },
-        ),
+//         leading: IconButton(
+//           tooltip: "Menu",
+//           icon: Icon(Icons.menu),
+//           onPressed: () {
+//             //Leading are the things before title
+//             print("Menu");
+//           },
+//         ),
         actions: <Widget>[
           IconButton(
             icon: customIcon,


### PR DESCRIPTION
fixes #1 

if you want any custom leading widget:
you have to call openDrawer function of the Scaffold. [refer here](https://stackoverflow.com/questions/47435231/open-drawer-on-clicking-appbar).